### PR TITLE
src: enable to custom check language by header's key

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ exports.register = function ( server, options, next ) {
       }
       request.i18n.setLocale( request.params.languageCode );
     }
+    if (pluginOptions.headerKey && pluginOptions.headerKey && request.headers[pluginOptions.headerKey]) {
+      request.i18n.setLocale(request.headers[pluginOptions.headerKey]);
+    }
     return reply.continue();
   });
   

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,21 @@ describe( "Localization", function() {
         }
       }
     });
+    server.route({
+      method: "GET",
+      path: "/localized/with/headers",
+      handler: function(request, reply) {
+        doSomething( function(){
+          return reply(
+            {
+              locale: request.i18n.getLocale(),
+              requestedLocale: request.headers["language"],
+              message: request.i18n.__( translateString_en )
+            }
+          );
+        });
+      }
+    })
 
     it( "can be added as plugin", function( done ) {
       server.register(
@@ -98,7 +113,8 @@ describe( "Localization", function() {
           register: Locale,
           options: {
             locales: ["de", "en", "fr"],
-            directory: __dirname + "/locales"
+            directory: __dirname + "/locales",
+            headerKey: "language"
           }
         },
         function ( err ) {
@@ -142,6 +158,24 @@ describe( "Localization", function() {
           }
         );
     });
+
+    it( "uses the requestd locale if language code is provided in headers", function(done) {
+      server.inject(
+        {
+          method: "GET",
+          url: "/localized/with/headers",
+          headers: {
+            "language": "fr"
+          }
+        },
+        function ( response ) {
+          response.result.locale.should.equal( "fr" );
+          response.result.requestedLocale.should.equal( "fr" );
+          response.result.message.should.equal( translateString_fr );
+          done();
+        }
+      )
+    })
 
     it( "translates localized strings in jade templates", function( done ) {
       server.inject(
@@ -258,7 +292,6 @@ describe( "Localization", function() {
               }
             }
           );
-        
       }
     })
     


### PR DESCRIPTION
enable hapi-i18n to add custom language key in request’s headers